### PR TITLE
Add config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# gradle
+
+.gradle/
+build/
+out/
+classes/
+
+# eclipse
+
+*.launch
+
+# idea
+
+.idea/
+*.iml
+*.ipr
+*.iws
+
+# vscode
+
+.settings/
+.vscode/
+bin/
+.classpath
+.project
+
+# fabric
+
+run/
+logs/
+gradle/

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ repositories {
 		name = "CottonMC"
 		url = "https://server.bbkr.space/artifactory/libs-release"
 	}
+
+	maven {
+		url = "https://ytg1234.github.io/maven"
+	}
 }
 
 dependencies {
@@ -54,8 +58,11 @@ dependencies {
 	// Config ease-of-use
 	modApi ("me.sargunvohra.mcmods:autoconfig1u:3.3.1") { exclude module: 'fabric-api' }
 	include "me.sargunvohra.mcmods:autoconfig1u:3.3.1"
-	// Config menu support
+	// Config menu support, optional dependency
 	modImplementation ("io.github.prospector:modmenu:1.14.13+build.19") { exclude module: 'fabric-api' }
+	// Recipe conditions, optional dependency
+	modImplementation("io.github.ytg1234:fabric-recipe-conditions:0.4.0")
+
 
 	compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,15 @@ dependencies {
 
 	modImplementation "io.github.cottonmc:LibGui:${project.libGui_version}"
 
+	// Config library
+	modApi ("me.shedaniel.cloth:config-2:4.8.3") { exclude module: 'fabric-api' }
+	include "me.shedaniel.cloth:config-2:4.8.3"
+	// Config ease-of-use
+	modApi ("me.sargunvohra.mcmods:autoconfig1u:3.3.1") { exclude module: 'fabric-api' }
+	include "me.sargunvohra.mcmods:autoconfig1u:3.3.1"
+	// Config menu support
+	modImplementation ("io.github.prospector:modmenu:1.14.13+build.19") { exclude module: 'fabric-api' }
+
 	compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@ maven_group=net.hyper_pigeon
 archives_base_name=Gizmos
 
 # Other APIs
-fabric_version=0.26.2+1.16
+fabric_version=0.29.2+1.16
 libGui_version=3.2.0+1.16.3

--- a/gradlew
+++ b/gradlew
@@ -82,6 +82,7 @@ esac
 
 CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
 
+
 # Determine the Java command to use to start the JVM.
 if [ -n "$JAVA_HOME" ] ; then
     if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
@@ -129,6 +130,7 @@ fi
 if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
+    
     JAVACMD=`cygpath --unix "$JAVACMD"`
 
     # We build the pattern for arguments to be converted via cygpath

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -29,6 +29,9 @@ if "%DIRNAME%" == "" set DIRNAME=.
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
+@rem Resolve any "." and ".." in APP_HOME to make it shorter.
+for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
+
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
 
@@ -80,6 +83,7 @@ set CMD_LINE_ARGS=%*
 @rem Setup the command line
 
 set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
 
 @rem Execute Gradle
 "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%

--- a/src/main/java/net/hyper_pigeon/Gizmos/Gizmos.java
+++ b/src/main/java/net/hyper_pigeon/Gizmos/Gizmos.java
@@ -5,6 +5,7 @@ import me.sargunvohra.mcmods.autoconfig1u.serializer.GsonConfigSerializer;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.object.builder.v1.client.model.FabricModelPredicateProviderRegistry;
 import net.hyper_pigeon.Gizmos.config.GizmosConfig;
+import net.hyper_pigeon.Gizmos.mixin.MixinConditions;
 import net.hyper_pigeon.Gizmos.registry.GizmoBlocks;
 import net.hyper_pigeon.Gizmos.registry.GizmoEntities;
 import net.hyper_pigeon.Gizmos.registry.GizmoItems;
@@ -15,15 +16,10 @@ import org.apache.logging.log4j.Logger;
 public class Gizmos implements ModInitializer {
 	public static final Logger LOGGER = LogManager.getLogger("Gizmos");
 
-	public static final GizmosConfig CONFIG = AutoConfig.getConfigHolder(GizmosConfig.class).getConfig();
-//	public static GizmosConfig getConfig() {
-//		return config;
-//	}
+	public static final GizmosConfig CONFIG = MixinConditions.CONFIG;
 
 	@Override
 	public void onInitialize() {
-//		AutoConfig.register(GizmosConfig.class, GsonConfigSerializer::new);
-//		config = AutoConfig.getConfigHolder(GizmosConfig.class).getConfig();
 		GizmoItems.init();
 		GizmoEntities.init();
 		GizmoBlocks.init();

--- a/src/main/java/net/hyper_pigeon/Gizmos/Gizmos.java
+++ b/src/main/java/net/hyper_pigeon/Gizmos/Gizmos.java
@@ -1,7 +1,10 @@
 package net.hyper_pigeon.Gizmos;
 
+import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import me.sargunvohra.mcmods.autoconfig1u.serializer.GsonConfigSerializer;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.object.builder.v1.client.model.FabricModelPredicateProviderRegistry;
+import net.hyper_pigeon.Gizmos.config.GizmosConfig;
 import net.hyper_pigeon.Gizmos.registry.GizmoBlocks;
 import net.hyper_pigeon.Gizmos.registry.GizmoEntities;
 import net.hyper_pigeon.Gizmos.registry.GizmoItems;
@@ -12,8 +15,15 @@ import org.apache.logging.log4j.Logger;
 public class Gizmos implements ModInitializer {
 	public static final Logger LOGGER = LogManager.getLogger("Gizmos");
 
+	public static final GizmosConfig CONFIG = AutoConfig.getConfigHolder(GizmosConfig.class).getConfig();
+//	public static GizmosConfig getConfig() {
+//		return config;
+//	}
+
 	@Override
 	public void onInitialize() {
+//		AutoConfig.register(GizmosConfig.class, GsonConfigSerializer::new);
+//		config = AutoConfig.getConfigHolder(GizmosConfig.class).getConfig();
 		GizmoItems.init();
 		GizmoEntities.init();
 		GizmoBlocks.init();

--- a/src/main/java/net/hyper_pigeon/Gizmos/config/GizmosConfig.java
+++ b/src/main/java/net/hyper_pigeon/Gizmos/config/GizmosConfig.java
@@ -9,6 +9,7 @@ public class GizmosConfig implements ConfigData {
     public boolean soulFireSpitter = true;
     public boolean fireworkStarBlock = true;
     public boolean chorusGourdAndCultivatedShulkers = true;
+    public boolean horseshoes = true;
     public boolean rideableRavagers = true;
-    public boolean horseShoes = true;
+    public boolean pillagerFireworks = true;
 }

--- a/src/main/java/net/hyper_pigeon/Gizmos/config/GizmosConfig.java
+++ b/src/main/java/net/hyper_pigeon/Gizmos/config/GizmosConfig.java
@@ -1,0 +1,14 @@
+package net.hyper_pigeon.Gizmos.config;
+
+import me.sargunvohra.mcmods.autoconfig1u.ConfigData;
+import me.sargunvohra.mcmods.autoconfig1u.annotation.Config;
+
+@Config(name = "gizmos")
+public class GizmosConfig implements ConfigData {
+    public boolean slingShot = true;
+    public boolean soulFireSpitter = true;
+    public boolean fireworkStarBlock = true;
+    public boolean chorusGourdAndCultivatedShulkers = true;
+    public boolean rideableRavagers = true;
+    public boolean horseShoes = true;
+}

--- a/src/main/java/net/hyper_pigeon/Gizmos/config/GizmosModMenuIntegration.java
+++ b/src/main/java/net/hyper_pigeon/Gizmos/config/GizmosModMenuIntegration.java
@@ -1,0 +1,36 @@
+package net.hyper_pigeon.Gizmos.config;
+
+import io.github.prospector.modmenu.api.ConfigScreenFactory;
+import io.github.prospector.modmenu.api.ModMenuApi;
+import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.hyper_pigeon.Gizmos.config.GizmosConfig;
+import net.minecraft.client.gui.screen.Screen;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+@Environment(EnvType.CLIENT)
+public class GizmosModMenuIntegration implements ModMenuApi {
+    @Override
+    public String getModId() {
+        return "gizmos";
+    }
+
+    @Override
+    public ConfigScreenFactory<?> getModConfigScreenFactory() {
+        return parent -> {
+            Optional<Supplier<Screen>> optionalScreen = getConfigScreen(parent);
+            if(optionalScreen.isPresent()) {
+                return optionalScreen.get().get();
+            } else {
+                return parent;
+            }
+        };
+    }
+
+    public Optional<Supplier<Screen>> getConfigScreen(Screen screen) {
+        return Optional.of(AutoConfig.getConfigScreen(GizmosConfig.class, screen));
+    }
+}

--- a/src/main/java/net/hyper_pigeon/Gizmos/mixin/MixinConditions.java
+++ b/src/main/java/net/hyper_pigeon/Gizmos/mixin/MixinConditions.java
@@ -10,6 +10,8 @@ import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 import java.util.List;
 import java.util.Set;
 
+import static org.apache.commons.lang3.StringUtils.endsWithAny;
+
 public class MixinConditions implements IMixinConfigPlugin {
     static {
         // must register here, registering in Gizmos doesn't happen in time
@@ -33,6 +35,21 @@ public class MixinConditions implements IMixinConfigPlugin {
 
         if (mixinClassName.endsWith("RavagerEntityMixin"))
             return CONFIG.rideableRavagers;
+
+        if (mixinClassName.endsWith("IronGolemEntityMixin"))
+            return CONFIG.rideableRavagers || CONFIG.chorusGourdAndCultivatedShulkers;
+
+        if (mixinClassName.endsWith("BipedEntityModel"))
+            return CONFIG.soulFireSpitter;
+
+        if (!CONFIG.horseshoes) {
+            return !endsWithAny(mixinClassName,
+                    "AbstractDonkeyEntityMixin",
+                    "HorseBaseEntityMixin",
+                    "HorseEntityMixin",
+                    "SkeletonHorseEntityMixin",
+                    "ZombieHorseEntityMixin");
+        }
 
         return true;
     }

--- a/src/main/java/net/hyper_pigeon/Gizmos/mixin/MixinConditions.java
+++ b/src/main/java/net/hyper_pigeon/Gizmos/mixin/MixinConditions.java
@@ -1,0 +1,45 @@
+package net.hyper_pigeon.Gizmos.mixin;
+
+import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import me.sargunvohra.mcmods.autoconfig1u.serializer.GsonConfigSerializer;
+import net.hyper_pigeon.Gizmos.Gizmos;
+import net.hyper_pigeon.Gizmos.config.GizmosConfig;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class MixinConditions implements IMixinConfigPlugin {
+    static {
+        AutoConfig.register(GizmosConfig.class, GsonConfigSerializer::new);
+    }
+
+    private static final GizmosConfig CONFIG = AutoConfig.getConfigHolder(GizmosConfig.class).getConfig();
+
+    @Override
+    public void onLoad(String mixinPackage) {
+
+    }
+
+    @Override
+    public String getRefMapperConfig() { return null; }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) { }
+
+    @Override
+    public List<String> getMixins() { return null; }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) { }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) { }
+}

--- a/src/main/java/net/hyper_pigeon/Gizmos/mixin/MixinConditions.java
+++ b/src/main/java/net/hyper_pigeon/Gizmos/mixin/MixinConditions.java
@@ -2,7 +2,6 @@ package net.hyper_pigeon.Gizmos.mixin;
 
 import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
 import me.sargunvohra.mcmods.autoconfig1u.serializer.GsonConfigSerializer;
-import net.hyper_pigeon.Gizmos.Gizmos;
 import net.hyper_pigeon.Gizmos.config.GizmosConfig;
 import org.objectweb.asm.tree.ClassNode;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
@@ -29,6 +28,12 @@ public class MixinConditions implements IMixinConfigPlugin {
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        if (mixinClassName.endsWith("PillagerEntityMixin"))
+            return CONFIG.pillagerFireworks;
+
+        if (mixinClassName.endsWith("RavagerEntityMixin"))
+            return CONFIG.rideableRavagers;
+
         return true;
     }
 

--- a/src/main/java/net/hyper_pigeon/Gizmos/mixin/MixinConditions.java
+++ b/src/main/java/net/hyper_pigeon/Gizmos/mixin/MixinConditions.java
@@ -13,10 +13,11 @@ import java.util.Set;
 
 public class MixinConditions implements IMixinConfigPlugin {
     static {
+        // must register here, registering in Gizmos doesn't happen in time
         AutoConfig.register(GizmosConfig.class, GsonConfigSerializer::new);
     }
 
-    private static final GizmosConfig CONFIG = AutoConfig.getConfigHolder(GizmosConfig.class).getConfig();
+    public static final GizmosConfig CONFIG = AutoConfig.getConfigHolder(GizmosConfig.class).getConfig();
 
     @Override
     public void onLoad(String mixinPackage) {

--- a/src/main/java/net/hyper_pigeon/Gizmos/registry/GizmoBlocks.java
+++ b/src/main/java/net/hyper_pigeon/Gizmos/registry/GizmoBlocks.java
@@ -1,6 +1,7 @@
 package net.hyper_pigeon.Gizmos.registry;
 
 import net.fabricmc.fabric.api.screenhandler.v1.ScreenHandlerRegistry;
+import net.hyper_pigeon.Gizmos.Gizmos;
 import net.hyper_pigeon.Gizmos.blocks.*;
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Material;
@@ -36,14 +37,17 @@ public class GizmoBlocks {
 //            Registry.register(Registry.BLOCK_ENTITY_TYPE, new Identifier("gizmos","firework_crafting_block"), BlockEntityType.Builder.create(FireworkCraftingBlockEntity::new, FIREWORK_CRAFTING_BLOCK).build(null));
 
     public static void init(){
-        Registry.register(Registry.BLOCK, new Identifier("gizmos", "chorus_gourd"), CHORUS_GOURD);
-        Registry.register(Registry.ITEM, new Identifier("gizmos", "chorus_gourd"),
-                new BlockItem(CHORUS_GOURD, new Item.Settings().group(ItemGroup.MISC)));
+        if (Gizmos.CONFIG.chorusGourdAndCultivatedShulkers) {
+            Registry.register(Registry.BLOCK, new Identifier("gizmos", "chorus_gourd"), CHORUS_GOURD);
+            Registry.register(Registry.ITEM, new Identifier("gizmos", "chorus_gourd"),
+                    new BlockItem(CHORUS_GOURD, new Item.Settings().group(ItemGroup.MISC)));
+        }
 
-
-        Registry.register(Registry.BLOCK, new Identifier("gizmos", "firework_star_block"), FIREWORK_STAR_BLOCK);
-        Registry.register(Registry.ITEM, new Identifier("gizmos", "firework_star_block"),
-                new BlockItem(FIREWORK_STAR_BLOCK, new Item.Settings().group(ItemGroup.MISC)));
+        if (Gizmos.CONFIG.fireworkStarBlock) {
+            Registry.register(Registry.BLOCK, new Identifier("gizmos", "firework_star_block"), FIREWORK_STAR_BLOCK);
+            Registry.register(Registry.ITEM, new Identifier("gizmos", "firework_star_block"),
+                    new BlockItem(FIREWORK_STAR_BLOCK, new Item.Settings().group(ItemGroup.MISC)));
+        }
 
 
 //        Registry.register(Registry.BLOCK, new Identifier("gizmos", "firework_crafting_block"), FIREWORK_CRAFTING_BLOCK);

--- a/src/main/java/net/hyper_pigeon/Gizmos/registry/GizmoEntities.java
+++ b/src/main/java/net/hyper_pigeon/Gizmos/registry/GizmoEntities.java
@@ -2,6 +2,7 @@ package net.hyper_pigeon.Gizmos.registry;
 
 import net.fabricmc.fabric.api.entity.FabricEntityTypeBuilder;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricDefaultAttributeRegistry;
+import net.hyper_pigeon.Gizmos.Gizmos;
 import net.hyper_pigeon.Gizmos.entities.CultivatedShulkerEntity;
 import net.hyper_pigeon.Gizmos.entities.TamedRavagerEntity;
 import net.minecraft.entity.EntityDimensions;
@@ -26,7 +27,10 @@ public class GizmoEntities {
 
 
     public static void init(){
-        FabricDefaultAttributeRegistry.register(CULTIVATED_SHULKER_ENTITY, ShulkerEntity.createShulkerAttributes());
-        FabricDefaultAttributeRegistry.register(TAMED_RAVAGER_ENTITY, RavagerEntity.createRavagerAttributes());
+        if (Gizmos.CONFIG.chorusGourdAndCultivatedShulkers)
+            FabricDefaultAttributeRegistry.register(CULTIVATED_SHULKER_ENTITY, ShulkerEntity.createShulkerAttributes());
+
+        if (Gizmos.CONFIG.rideableRavagers)
+            FabricDefaultAttributeRegistry.register(TAMED_RAVAGER_ENTITY, RavagerEntity.createRavagerAttributes());
     }
 }

--- a/src/main/java/net/hyper_pigeon/Gizmos/registry/GizmoItems.java
+++ b/src/main/java/net/hyper_pigeon/Gizmos/registry/GizmoItems.java
@@ -34,7 +34,7 @@ public class GizmoItems {
         if (Gizmos.CONFIG.slingShot)
             Registry.register(Registry.ITEM, new Identifier("gizmos","slingshot"), SLINGSHOT);
 
-        if (Gizmos.CONFIG.horseShoes)
+        if (Gizmos.CONFIG.horseshoes)
             Registry.register(Registry.ITEM, new Identifier("gizmos","horseshoes"), HORSESHOES);
     }
 

--- a/src/main/java/net/hyper_pigeon/Gizmos/registry/GizmoItems.java
+++ b/src/main/java/net/hyper_pigeon/Gizmos/registry/GizmoItems.java
@@ -1,5 +1,6 @@
 package net.hyper_pigeon.Gizmos.registry;
 
+import net.hyper_pigeon.Gizmos.Gizmos;
 import net.hyper_pigeon.Gizmos.items.Horseshoes;
 import net.hyper_pigeon.Gizmos.items.Slingshot;
 import net.hyper_pigeon.Gizmos.items.SoulFireSpitter;
@@ -27,9 +28,14 @@ public class GizmoItems {
             EntityAttributeModifier.Operation.fromId(0));
 
     public static void init(){
-        Registry.register(Registry.ITEM,new Identifier("gizmos","soul_fire_spitter"), SOUL_FIRE_SPITTER);
-        Registry.register(Registry.ITEM, new Identifier("gizmos","slingshot"), SLINGSHOT);
-        Registry.register(Registry.ITEM, new Identifier("gizmos","horseshoes"), HORSESHOES);
+        if (Gizmos.CONFIG.soulFireSpitter)
+            Registry.register(Registry.ITEM,new Identifier("gizmos","soul_fire_spitter"), SOUL_FIRE_SPITTER);
+
+        if (Gizmos.CONFIG.slingShot)
+            Registry.register(Registry.ITEM, new Identifier("gizmos","slingshot"), SLINGSHOT);
+
+        if (Gizmos.CONFIG.horseShoes)
+            Registry.register(Registry.ITEM, new Identifier("gizmos","horseshoes"), HORSESHOES);
     }
 
 }

--- a/src/main/resources/Gizmos.mixins.json
+++ b/src/main/resources/Gizmos.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "net.hyper_pigeon.Gizmos.mixin",
   "compatibilityLevel": "JAVA_8",
+  "plugin": "net.hyper_pigeon.Gizmos.mixin.MixinConditions",
   "mixins": [
     "BipedEntityModelMixin",
     "HorseBaseEntityMixin",

--- a/src/main/resources/assets/gizmos/lang/en_us.json
+++ b/src/main/resources/assets/gizmos/lang/en_us.json
@@ -11,5 +11,19 @@
 
   "item.gizmos.firework_star_block": "Firework Star Block",
 
-  "item.gizmos.horseshoes": "Horseshoes"
+  "item.gizmos.horseshoes": "Horseshoes",
+
+  "text.autoconfig.gizmos.option.slingShot": "Enable sling shot",
+
+  "text.autoconfig.gizmos.option.soulFireSpitter": "Enable soul fire spitter",
+
+  "text.autoconfig.gizmos.option.fireworkStarBlock": "Enable firework star block",
+
+  "text.autoconfig.gizmos.option.chorusGourdAndCultivatedShulkers": "Enable chorus gourd and cultivated shulkers",
+
+  "text.autoconfig.gizmos.option.horseshoes": "Enable horseshoes",
+
+  "text.autoconfig.gizmos.option.rideableRavagers": "Enable rideable ravagers",
+
+  "text.autoconfig.gizmos.option.pillagerFireworkStars": "Enable pillager firework stars"
 }

--- a/src/main/resources/data/gizmos/recipes/chorus_gourd.json
+++ b/src/main/resources/data/gizmos/recipes/chorus_gourd.json
@@ -16,5 +16,8 @@
   "result": {
     "item": "gizmos:chorus_gourd",
     "count": 1
-  }
+  },
+  "frc:conditions": [
+    { "recipeconditions:item_registered": "gizmos:chorus_gourd" }
+  ]
 }

--- a/src/main/resources/data/gizmos/recipes/firework_star_block.json
+++ b/src/main/resources/data/gizmos/recipes/firework_star_block.json
@@ -25,5 +25,8 @@
   "result": {
     "item": "gizmos:firework_star_block",
     "count": 1
-  }
+  },
+  "frc:conditions": [
+    { "recipeconditions:item_registered": "gizmos:firework_star_block" }
+  ]
 }

--- a/src/main/resources/data/gizmos/recipes/horseshoes.json
+++ b/src/main/resources/data/gizmos/recipes/horseshoes.json
@@ -16,5 +16,8 @@
   "result": {
     "item": "gizmos:horseshoes",
     "count": 1
-  }
+  },
+  "frc:conditions": [
+    { "recipeconditions:item_registered": "gizmos:horseshoes" }
+  ]
 }

--- a/src/main/resources/data/gizmos/recipes/slingshot.json
+++ b/src/main/resources/data/gizmos/recipes/slingshot.json
@@ -16,5 +16,8 @@
   "result": {
     "item": "gizmos:slingshot",
     "count": 1
-  }
+  },
+  "frc:conditions": [
+    { "recipeconditions:item_registered": "gizmos:slingshot" }
+  ]
 }

--- a/src/main/resources/data/gizmos/recipes/soul_fire_spitter.json
+++ b/src/main/resources/data/gizmos/recipes/soul_fire_spitter.json
@@ -28,5 +28,8 @@
     "data": {
       "Damage": 250
     }
-  }
+  },
+  "frc:conditions": [
+    { "recipeconditions:item_registered": "gizmos:soul_fire_spitter" }
+  ]
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,6 +20,9 @@
     ],
     "client": [
       "net.hyper_pigeon.Gizmos.GizmosClient"
+    ],
+    "modmenu": [
+      "net.hyper_pigeon.Gizmos.config.GizmosModMenuIntegration"
     ]
   },
   

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,8 +26,9 @@
     ]
   },
   
-  "requires": {
-    "fabricloader": ">=0.4.0"
+  "depends": {
+    "fabricloader": ">=0.4.0",
+    "fabric": ">=0.29"
   },
 
   "recommends": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,6 +29,11 @@
   "requires": {
     "fabricloader": ">=0.4.0"
   },
+
+  "recommends": {
+    "recipeconditions": "*",
+    "modmenu": "*"
+  },
   
   "mixins": [
     "Gizmos.mixins.json"


### PR DESCRIPTION
This adds configs for all features, using cloth config+auto config. 
Configs are checked in all `Gizmos/registry` classes' `init` methods, and in the new `MixinConditions` `IMixinConfigPlugin`. 
Also includes mod menu integration (optional dependency) and recipe conditions (optional dependency).

Caveats:
- An error will be logged when the Chorus Gourd loottable is loaded if the chorus gourd is not enabled. 
- Clients and severs must have matching configs for each of the items+blocks (rideable ravagers and pillager fireworks probably don't matter). If they don't match, either the client won't be able to connect because of missing registry entries, or there will be id de-syncs and the client will have miss-matched blocked (not sure which). 

I've tested some, but not exhaustively. 